### PR TITLE
Easier Install Method

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.md
+include LICENSE
+include requirements.txt
+include rBrowser.py
+include config
+recursive-include templates *
+recursive-include script *
+recursive-include settings *

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ NOTE: You don't need to run RNS manually, just make sure your instance is workin
 - Python 3.7+
 - pip or pipx
 - git (for installing from git repository)
+- Setuptools
 
 **Installation:**
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Web-Based UI: the rBrowser interface is spawned via local web server to your loc
 * [• ⚙️ Installation](#️-installation)
   * [⚡ Prerequisites](#-prerequisites)
   * [💻 Install Option 1: Run from Terminal](#-install-option-1-run-from-terminal)
-  * [🐳 Install Option 2: Docker & Docker Compose](#-install-option-2-docker--docker-compose)
+  * [📦 Install Option 2: Install via pip from git](#-install-option-2-install-via-pip-from-git)
+  * [🐳 Install Option 3: Docker & Docker Compose](#-install-option-3-docker--docker-compose)
 * [• 🚀 Usage](#-usage)
   * [🔗 URL Formats Supported](#-url-formats-supported)
   * [🧭 Navigation](#-navigation)
@@ -137,12 +138,45 @@ NOTE: You don't need to run RNS manually, just make sure your instance is workin
    - Discovered nodes will appear in the left sidebar
    - Click on any node to browse its content and navigate pages
    - or manually paste address in the bar without waiting for announces
-   - Check bottom-left Status Bar for connection status info 
+   - Check bottom-left Status Bar for connection status info
 
 
 ---
 
-## 🐳 Install Option 2: Docker & Docker Compose
+## 📦 Install Option 2: Install via pip from git
+
+**System Requirements:**
+- Python 3.7+
+- pip or pipx
+- git (for installing from git repository)
+
+**Installation:**
+
+```bash
+pip install git+https://github.com/fr33n0w/rBrowser.git
+```
+
+**Using Pipx:**
+
+```bash
+pipx install git+https://github.com/fr33n0w/rBrowser.git
+```
+
+**Usage:**
+
+```bash
+rBrowser
+```
+
+**Optional command line arguments:**
+
+```bash
+rBrowser [--host HOST] [--port PORT]
+```
+
+---
+
+## 🐳 Install Option 3: Docker & Docker Compose
 
 - This repository includes a Dockerfile and a docker-compose.yaml so you can run rBrowser in a container. 
 - The compose setup builds the image and exposes the web UI on port 5000.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+from setuptools import setup, find_packages
+import os
+
+# Read the README file
+def read_readme():
+    with open("README.md", "r", encoding="utf-8") as fh:
+        return fh.read()
+
+# Read requirements.txt
+def read_requirements():
+    with open("requirements.txt", "r", encoding="utf-8") as fh:
+        return [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+
+setup(
+    name="rBrowser",
+    version="1.0.0",
+    author="Franky, neoemit",
+    author_email="frankyros@gmail.com",
+    description="Standalone NomadNet Browser - A web-based UI for exploring NomadNet nodes over the Reticulum network",
+    long_description=read_readme(),
+    long_description_content_type="text/markdown",
+    license="MIT",
+    url="https://github.com/fr33n0w/rBrowser",
+    py_modules=["rBrowser"],
+    include_package_data=True,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Framework :: Flask",
+        "Intended Audience :: End Users/Desktop",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Topic :: Internet :: WWW/HTTP :: Browsers",
+        "Topic :: Communications",
+        "Topic :: System :: Networking",
+    ],
+    keywords="reticulum nomadnet browser mesh network decentralized",
+    python_requires=">=3.7",
+    install_requires=read_requirements(),
+    entry_points={
+        "console_scripts": [
+            "rBrowser=rBrowser:main",
+        ],
+    },
+    project_urls={
+        "Homepage": "https://github.com/fr33n0w/rBrowser",
+        "Repository": "https://github.com/fr33n0w/rBrowser",
+        "Issues": "https://github.com/fr33n0w/rBrowser/issues",
+        "Documentation": "https://github.com/fr33n0w/rBrowser#readme",
+    },
+)


### PR DESCRIPTION
This adds ability to install using git `pip install git+https://github.com/fr33n0w/rBrowser` or `pipx install git+https://github.com/fr33n0w/rBrowser`

Users can then just run `rBrowser` in terminal 

Allows for building python wheels as well. 

```
python setup.py sdist bdist_wheel
```

**Package managers supporting git method:**

- pip
- pipx
- uv
- poetry

**How to test using my branch:**

```
pip install git+https://github.com/Sudo-Ivan/rBrowser@easier-install
```

Run `rBrowser` in terminal.

Let me know if you want any changes or if this is not what you want.